### PR TITLE
Add table relationship tools

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -19,6 +19,7 @@ This documentation provides details on how to use the Model Context Protocol (MC
   - [list_tables](#list_tables)
   - [create_table](#create_table)
   - [update_table](#update_table)
+  - [get_table_relationships](#get_table_relationships)
 - [Field Tools](#field-tools)
   - [get_table_fields](#get_table_fields)
   - [create_field](#create_field)
@@ -289,6 +290,29 @@ mcp__quickbase__update_table(
   "created": "2023-03-21T17:15:00Z",
   "updated": "2023-03-21T17:30:45Z"
 }
+```
+
+### get_table_relationships
+
+Retrieves all relationships defined for a Quickbase table.
+
+**Parameters:**
+- `table_id` (string, required): The ID of the table
+
+**Example:**
+```
+mcp__quickbase__get_table_relationships(table_id="bqrxzt5wq")
+```
+
+**Response:**
+```
+[
+  {
+    "relationshipId": "6",
+    "parentTableId": "bqrxzt5wq",
+    "childTableId": "bqrxzt6wr"
+  }
+]
 ```
 
 ## Field Tools

--- a/src/quickbase/server.py
+++ b/src/quickbase/server.py
@@ -2207,7 +2207,21 @@ async def handle_list_tools() -> list[types.Tool]:
                 "required": ["table_id"],
             },
         ),
-        
+        types.Tool(
+            name="get_table_relationships",
+            description="Retrieves table relationships for a specific Quickbase table",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "table_id": {
+                        "type": "string",
+                        "description": "The ID of the Quickbase table",
+                    },
+                },
+                "required": ["table_id"],
+            },
+        ),
+
         # Field Operations
         types.Tool(
             name="get_table_fields",
@@ -2699,6 +2713,18 @@ async def handle_call_tool(name: str, arguments: dict[str, str]) -> list[types.T
                 types.TextContent(
                     type="text",
                     text=f"Table Fields (JSON):\n{json.dumps(results, indent=2)}",
+                )
+            ]
+        elif name == "get_table_relationships":
+            table_id = arguments.get("table_id")
+            if not table_id:
+                raise ValueError("Missing 'table_id' argument")
+
+            results = qb_client.get_table_relationships(table_id)
+            return [
+                types.TextContent(
+                    type="text",
+                    text=f"Table Relationships (JSON):\n{json.dumps(results, indent=2)}",
                 )
             ]
         elif name == "create_record":

--- a/tests/validate_implementation.py
+++ b/tests/validate_implementation.py
@@ -166,10 +166,19 @@ async def test_list_tables():
 async def test_get_table_fields():
     """Test getting table fields"""
     return await run_test(
-        "Get Table Fields", 
-        "get_table_fields", 
+        "Get Table Fields",
+        "get_table_fields",
         {"table_id": TABLE_ID},
         lambda r: any("Table Fields" in c.text for c in r)
+    )
+
+async def test_get_table_relationships():
+    """Test getting table relationships"""
+    return await run_test(
+        "Get Table Relationships",
+        "get_table_relationships",
+        {"table_id": TABLE_ID},
+        lambda r: any("Table Relationships" in c.text for c in r)
     )
 
 async def test_create_record():
@@ -452,6 +461,7 @@ async def run_all_tests():
         await test_connection()
         await test_list_tables()
         await test_get_table_fields()
+        await test_get_table_relationships()
         await test_create_record()
         await test_query_records()
         


### PR DESCRIPTION
## Summary
- add `get_table_relationships` tool to the Quickbase MCP server
- expose the tool via `handle_call_tool`
- document new tool in `docs/tools.md`
- test `get_table_relationships` in validation script

## Testing
- `python tests/validate_implementation.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*